### PR TITLE
add empty parameters to load()

### DIFF
--- a/tetra/components/base.py
+++ b/tetra/components/base.py
@@ -159,7 +159,7 @@ class BasicComponent(object, metaclass=BasicComponentMetaClass):
     def _call_load(self, *args, **kwargs):
         self.load(*args, **kwargs)
 
-    def load(self) -> None:
+    def load(self, *args, **kwargs):
         pass
 
     def _add_to_context(self, context):


### PR DESCRIPTION
if subclasses override `load()` with some parameters, IDEs should not see that as error.